### PR TITLE
fix(nvim): resolve unintended keymap override

### DIFF
--- a/.config/nvim/lua/plugins/configs/copilot.lua
+++ b/.config/nvim/lua/plugins/configs/copilot.lua
@@ -3,7 +3,7 @@ local function config()
 	local key = vim.keymap.set
 	local opt = { silent = true, expr = true, script = true, replace_keycodes = false }
 
-	key("i", "<C-g>", 'copilot#Accept("<CR>")', opt)
+	key("i", "<C-g><CR>", 'copilot#Accept("")', opt)
 	key("i", "<C-j>", "<Plug>(copilot-next)")
 	key("i", "<C-k>", "<Plug>(copilot-previous)")
 	key("i", "<C-o>", "<Plug>(copilot-dismiss)")
@@ -16,5 +16,5 @@ return {
 		return vim.env.USER ~= "ushmz"
 	end,
 	config = config,
-	event = { "InsertEnter" },
+	event = { "BufRead" },
 }


### PR DESCRIPTION
If `copilot.vim` is loaded after `telescope.nvim`, it override <Tab> keymap. To avoid this behavior, change `copilot.vim`'s load event to `BufRead` and make sure it's loaded before `telescope.nvim` is loaded.