### PR TITLE
feat: add image.nvim for in-editor image rendering

### DIFF
--- a/.config/nvim/lua/plugins/configs/image.lua
+++ b/.config/nvim/lua/plugins/configs/image.lua
@@ -1,0 +1,26 @@
+return {
+  "3rd/image.nvim",
+  lazy = false,
+  -- so that it doesn't build the rock
+  -- @see https://github.com/3rd/image.nvim/issues/91#issuecomment-2453430239
+  build = false,
+  cond = function()
+    local term = require("utils").term()
+    return vim.tbl_contains({ "xterm-ghostty", "xterm-kitty" }, term)
+  end,
+  opts = {
+    processor = "magick_cli",
+    integrations = {
+      markdown = {
+        clear_in_insert_mode = true,
+        only_render_image_at_cursor = false,
+        only_render_image_at_cursor_mode = "inline",
+      },
+      asciidoc = {
+        clear_in_insert_mode = true,
+        only_render_image_at_cursor = false,
+        only_render_image_at_cursor_mode = "inline",
+      },
+    },
+  },
+}

--- a/.config/nvim/lua/utils/init.lua
+++ b/.config/nvim/lua/utils/init.lua
@@ -14,4 +14,16 @@ M.flatten = function(tbl)
   return vim.iter(tbl):flatten():totable()
 end
 
+---Return the terminal emulator name.
+---Inside tmux, `TERM_PROGRAM` is overridden to "tmux", so use
+---`#{client_termname}` to get the actual outer terminal's TERM value instead.
+---@return string
+M.term = function()
+  if vim.env.TMUX then
+    return vim.fn.system("tmux display-message -p '#{client_termname}'"):gsub("%s+$", "")
+  end
+
+  return vim.env.TERM_PROGRAM
+end
+
 return M

--- a/.config/nvim/lua/utils/init.lua
+++ b/.config/nvim/lua/utils/init.lua
@@ -20,10 +20,11 @@ end
 ---@return string
 M.term = function()
   if vim.env.TMUX then
-    return vim.fn.system("tmux display-message -p '#{client_termname}'"):gsub("%s+$", "")
+    local term, _ = vim.fn.system("tmux display-message -p '#{client_termname}'"):gsub("%s+$", "")
+    return term
   end
 
-  return vim.env.TERM_PROGRAM
+  return vim.env.TERM
 end
 
 return M

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -8,6 +8,9 @@ set -s escape-time 0
 set -g base-index 1
 set -g mouse on
 set -g focus-events on
+# Allow passthrough for image rendering protocols
+set -gq allow-passthrough on
+set -g visual-activity off
 
 # Clipboard
 set -s set-clipboard on


### PR DESCRIPTION
## Summary

- Add image.nvim plugin to render images inline in Neovim
- Add `utils.term()` to detect the outer terminal name correctly inside tmux (falls back to `TERM` outside tmux)
- Skip loading image.nvim on unsupported terminals (`xterm-ghostty` and `xterm-kitty` are supported)
- Enable tmux passthrough required for image rendering protocols